### PR TITLE
SwitchFilePathSeparators: improvement

### DIFF
--- a/src/osmedile/intellij/stringmanip/SwitchFilePathSeparators.java
+++ b/src/osmedile/intellij/stringmanip/SwitchFilePathSeparators.java
@@ -2,6 +2,8 @@ package osmedile.intellij.stringmanip;
 
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.Pair;
+import org.jetbrains.annotations.NotNull;
 
 public class SwitchFilePathSeparators extends AbstractStringManipAction {
 
@@ -12,13 +14,49 @@ public class SwitchFilePathSeparators extends AbstractStringManipAction {
         super(setupHandler);
     }
 
+
+    enum SwitchTo {
+        op_Unknown,
+        op_SlashToBackslash,
+        op_BackslashToSlash
+    }
+
+    private SwitchTo replaceOperation = SwitchTo.op_Unknown;
+
+    @NotNull
+    @Override
+    public Pair beforeWriteAction(Editor editor, DataContext dataContext) {
+        replaceOperation = SwitchTo.op_Unknown;
+        return super.beforeWriteAction(editor, dataContext);
+    }
+
 	@Override
 	public String transformByLine(String s) {
         String s1;
-        if (s.contains("/")) {
+        if (replaceOperation == SwitchTo.op_Unknown) {
+            int fslash = s.indexOf('/');
+            int bslash = s.indexOf('\\');
+
+            boolean slashDetected = (bslash >= 0) || (fslash >= 0);
+            if (slashDetected) {
+                if ((fslash >= 0) && (bslash >= 0)) {
+                    replaceOperation = (bslash < fslash) ? SwitchTo.op_BackslashToSlash : SwitchTo.op_SlashToBackslash;
+                } else {
+                    replaceOperation = (bslash >= 0) ? SwitchTo.op_BackslashToSlash : SwitchTo.op_SlashToBackslash;
+                }
+            }
+        }
+        switch (replaceOperation) {
+            case op_SlashToBackslash:
             s1 = s.replace("/", "\\");
-        } else {
+                break;
+            case op_BackslashToSlash:
             s1 = s.replace("\\", "/");
+                break;
+            case op_Unknown:
+            default:
+                s1 = s;
+                break;
         }
         return s1;
 	}

--- a/src/osmedile/intellij/stringmanip/SwitchFilePathSeparators.java
+++ b/src/osmedile/intellij/stringmanip/SwitchFilePathSeparators.java
@@ -5,19 +5,21 @@ import com.intellij.openapi.editor.Editor;
 
 public class SwitchFilePathSeparators extends AbstractStringManipAction {
 
-	@Override
-	public String transformSelection(Editor editor, DataContext dataContext, String s, Object additionalParam) {
-		String s1;
-		if (s.contains("/")) {
-			s1 = s.replace("/", "\\");
-		} else {
-			s1 = s.replace("\\", "/");
-		}
-		return s1;
-	}
+    protected SwitchFilePathSeparators() {
+    }
+
+    protected SwitchFilePathSeparators(boolean setupHandler) {
+        super(setupHandler);
+    }
 
 	@Override
 	public String transformByLine(String s) {
-		throw new UnsupportedOperationException();
+        String s1;
+        if (s.contains("/")) {
+            s1 = s.replace("/", "\\");
+        } else {
+            s1 = s.replace("\\", "/");
+        }
+        return s1;
 	}
 }

--- a/test/osmedile/intellij/stringmanip/SwitchFilePathSeparatorsTest.java
+++ b/test/osmedile/intellij/stringmanip/SwitchFilePathSeparatorsTest.java
@@ -1,0 +1,69 @@
+package osmedile.intellij.stringmanip;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SwitchFilePathSeparatorsTest {
+
+    protected SwitchFilePathSeparators action;
+
+    @Test
+    public void testSwitchFilePathSeparators_BackslashToSlash() {
+        action = new SwitchFilePathSeparators(false);
+        Assert.assertEquals("Foo bar Wee All", action.transformByLine("Foo bar Wee All"));
+        // first found determine op
+        Assert.assertEquals("Foo/bar/foo", action.transformByLine("Foo\\bar\\foo"));
+        // second works same
+        Assert.assertEquals("Foo/bar/foo", action.transformByLine("Foo\\bar\\foo"));
+        // don't change action
+        Assert.assertEquals("Foo/bar/foo", action.transformByLine("Foo/bar/foo"));
+    }
+
+    @Test
+    public void testSwitchFilePathSeparators_BackslashToSlashMix() {
+        action = new SwitchFilePathSeparators(false);
+        Assert.assertEquals("Foo bar Wee All", action.transformByLine("Foo bar Wee All"));
+        // first found determine op
+        Assert.assertEquals("Foo/bar/foo/bar", action.transformByLine("Foo\\bar\\foo/bar"));
+        // second works same
+        Assert.assertEquals("Foo/bar/foo/bar", action.transformByLine("Foo\\bar\\foo/bar"));
+        // don't change action
+        Assert.assertEquals("Foo/bar/foo", action.transformByLine("Foo/bar/foo"));
+    }
+
+    @Test
+    public void testSwitchFilePathSeparators_BackslashToSlashSingle() {
+        action = new SwitchFilePathSeparators(false);
+        Assert.assertEquals("Foo/bar/foo/bar", action.transformByLine("Foo\\bar\\foo\\bar"));
+    }
+
+
+    @Test
+    public void testSwitchFilePathSeparators_SlashToBackSlash() {
+        action = new SwitchFilePathSeparators(false);
+        // first found determine op
+        Assert.assertEquals("Foo\\bar\\foo", action.transformByLine("Foo/bar/foo"));
+        // second works same
+        Assert.assertEquals("Foo\\bar\\foo", action.transformByLine("Foo/bar/foo"));
+        // don't change action
+        Assert.assertEquals("Foo\\bar\\foo", action.transformByLine("Foo\\bar\\foo"));
+    }
+    @Test
+    public void testSwitchFilePathSeparators_SlashToBackSlashMix() {
+        action = new SwitchFilePathSeparators(false);
+        Assert.assertEquals("Foo bar Wee All", action.transformByLine("Foo bar Wee All"));
+        // first found determine op
+        Assert.assertEquals("Foo\\bar\\foo\\bar", action.transformByLine("Foo/bar/foo\\bar"));
+        // second works same
+        Assert.assertEquals("Foo\\bar\\foo\\bar", action.transformByLine("Foo/bar/foo\\bar"));
+        // don't change action
+        Assert.assertEquals("Foo\\bar\\foo", action.transformByLine("Foo\\bar\\foo"));
+    }
+
+    @Test
+    public void testSwitchFilePathSeparators_SlashToBackSlashSingle() {
+        action = new SwitchFilePathSeparators(false);
+        Assert.assertEquals("Foo\\bar\\foo", action.transformByLine("Foo/bar/foo"));
+    }
+
+}


### PR DESCRIPTION
The first found seperator determines the operation "\" -> "/" or versa for the whole line selection .
See the new Unit Test for the improved behavior of SwitchFilePathSeparators.