### PR TITLE
Timestamp decode/encode

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -246,6 +246,17 @@
                         text="Decode URL (RFC 3986)"
                         description="Decode URL (RFC 3986 - space character as %20 instead of +)">
                 </action>
+                <separator/>
+                <action id="osmedile.intellij.stringmanip.encoding.TimestampEncodeAction"
+                        class="osmedile.intellij.stringmanip.encoding.TimestampEncodeAction"
+                        text="Encode Instant"
+                        description="Encode Instant as epoch milliseconds">
+                </action>
+                <action id="osmedile.intellij.stringmanip.encoding.TimestampDecodeAction"
+                        class="osmedile.intellij.stringmanip.encoding.TimestampDecodeAction"
+                        text="Decode Instant"
+                        description="Decode epoch milliseconds as Instant">
+                </action>
             </group>
 
             <separator/>

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Provides actions for text manipulation:
             <li>De/Encode selected text as URL</li>
             <li>De/Encode selected text to Base64</li>
             <li>De/Encode selected text to Hex</li>
+            <li>De/Encode selected text to Timestamp</li>
     </ul>
     </p>
     <p>

--- a/src/osmedile/intellij/stringmanip/encoding/TimestampDecodeAction.java
+++ b/src/osmedile/intellij/stringmanip/encoding/TimestampDecodeAction.java
@@ -1,0 +1,21 @@
+package osmedile.intellij.stringmanip.encoding;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import osmedile.intellij.stringmanip.AbstractStringManipAction;
+import osmedile.intellij.stringmanip.utils.TimestampUtils;
+
+import java.util.Map;
+
+public class TimestampDecodeAction extends AbstractStringManipAction<Object> {
+
+    @Override
+    protected String transformSelection(Editor editor, Map<String, Object> actionContext, DataContext dataContext, String selectedText, Object additionalParam) {
+        return TimestampUtils.decodeTimestamp(selectedText);
+    }
+
+    @Override
+    public String transformByLine(Map<String, Object> actionContext, String s) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/osmedile/intellij/stringmanip/encoding/TimestampEncodeAction.java
+++ b/src/osmedile/intellij/stringmanip/encoding/TimestampEncodeAction.java
@@ -1,0 +1,22 @@
+package osmedile.intellij.stringmanip.encoding;
+
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.editor.Editor;
+import osmedile.intellij.stringmanip.AbstractStringManipAction;
+import osmedile.intellij.stringmanip.utils.EncodingUtils;
+import osmedile.intellij.stringmanip.utils.TimestampUtils;
+
+import java.util.Map;
+
+public class TimestampEncodeAction extends AbstractStringManipAction<Object> {
+
+    @Override
+    protected String transformSelection(Editor editor, Map<String, Object> actionContext, DataContext dataContext, String selectedText, Object additionalParam) {
+        return TimestampUtils.encodeTimestamp(selectedText);
+    }
+
+    @Override
+    public String transformByLine(Map<String, Object> actionContext, String s) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/osmedile/intellij/stringmanip/utils/TimestampUtils.java
+++ b/src/osmedile/intellij/stringmanip/utils/TimestampUtils.java
@@ -1,0 +1,44 @@
+package osmedile.intellij.stringmanip.utils;
+
+import java.time.*;
+import java.time.format.DateTimeParseException;
+
+public class TimestampUtils {
+    public static String decodeTimestamp(String selectedText) {
+        try {
+            long millis = Long.parseLong(selectedText);
+            return Instant.ofEpochMilli(millis).toString();
+        } catch (NumberFormatException | DateTimeException e) {
+            return selectedText;
+        }
+    }
+
+
+    public static String encodeTimestamp(String selectedText) {
+        Instant instant = parseAny(selectedText);
+        if (instant == null) return selectedText;
+        return String.valueOf(instant.toEpochMilli());
+    }
+
+    private static Instant parseAny(String input) {
+        for (int state = 0; ; ++state) {
+            try {
+                switch (state) {
+                    case 0:
+                        return Instant.parse(input);
+                    case 1:
+                        return ZonedDateTime.parse(input).toInstant();
+                    case 2:
+                        return OffsetDateTime.parse(input).toInstant();
+                    case 3:
+                        return LocalDateTime.parse(input).toInstant(ZoneOffset.UTC);
+                    case 4:
+                        return LocalDate.parse(input).atStartOfDay().toInstant(ZoneOffset.UTC);
+                    default:
+                        return null;
+                }
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+    }
+}

--- a/test/osmedile/intellij/stringmanip/utils/EncodingUtilsTest.java
+++ b/test/osmedile/intellij/stringmanip/utils/EncodingUtilsTest.java
@@ -39,5 +39,23 @@ public class EncodingUtilsTest {
         Assert.assertEquals("foo+bar", EncodingUtils.decodeUrl("foo%2Bbar"));
     }
 
+    @Test
+    public void decodeTimestamp() {
+        Assert.assertEquals("2020-10-28T15:59:23.123Z", TimestampUtils.decodeTimestamp("1603900763123"));
+        Assert.assertEquals("2020-10-28T15:59:23Z", TimestampUtils.decodeTimestamp("1603900763000"));
+        Assert.assertEquals("2020-10-28T15:59:00Z", TimestampUtils.decodeTimestamp("1603900740000"));
+        Assert.assertEquals("2020-10-28T00:00:00Z", TimestampUtils.decodeTimestamp("1603843200000"));
+    }
 
+    @Test
+    public void encodeTimestamp() {
+        Assert.assertEquals("1603900763123", TimestampUtils.encodeTimestamp("2020-10-28T15:59:23.123Z"));
+        Assert.assertEquals("1603900763000", TimestampUtils.encodeTimestamp("2020-10-28T15:59:23Z"));
+        Assert.assertEquals("1603900740000", TimestampUtils.encodeTimestamp("2020-10-28T15:59Z"));
+        Assert.assertEquals("1603897163000", TimestampUtils.encodeTimestamp("2020-10-28T15:59:23+01:00"));
+        Assert.assertEquals("1603897163000", TimestampUtils.encodeTimestamp("2020-10-28T15:59:23+01:00[Europe/Prague]"));
+        Assert.assertEquals("1603900763000", TimestampUtils.encodeTimestamp("2020-10-28T15:59:23"));
+        Assert.assertEquals("1603900740000", TimestampUtils.encodeTimestamp("2020-10-28T15:59"));
+        Assert.assertEquals("1603843200000", TimestampUtils.encodeTimestamp("2020-10-28"));
+    }
 }


### PR DESCRIPTION
Hi, I wanted to suggest a feature, but why not implement it right away.
I'm a Scala developer and I often deal with timestamps encoded as epoch milliseconds, which are hard to read and work with.

This PR adds 2 actions under Encode/Decode that convert between milliseconds and ISO timestamp (`java.time.Instant`). The input parsing is lenient and can understand (the absence of) timezones (defaults to UTC) or date without time (assumes start of day). See tests for examples.

It doesn't cover:
* error reporting - any exception will ignore the action
* UNIX seconds - I have no use for this ¯\\_(ツ)_/¯

I love your plugin, it has been invaluable to me, I would be very glad for this to be included in the official distribution.
Let me know if you need me to change anything or have other suggestions.