### PR TITLE
Correct "Hiarchical" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Provides actions for text manipulation:
             <li>Sort hexadecimally</li>
             <li>Sort lines by subselection - only one selection/caret per line is handled</li>
             <li>Sort tokens (delimited text)</li>
-	    <li><a href="https://github.com/krasa/StringManipulation/wiki/Hiarchical-sort/" >Hiearchical sort</a></li>
+	    <li><a href="https://github.com/krasa/StringManipulation/wiki/Hierarchical-sort/">Hierarchical sort</a></li>
         </ul>
     </p>
     <p>

--- a/src/osmedile/intellij/stringmanip/sort/support/SortTypeDialog.java
+++ b/src/osmedile/intellij/stringmanip/sort/support/SortTypeDialog.java
@@ -180,7 +180,7 @@ enabledByAny(new JComponent[]{levelRegex, levelRegexLabel}, groupSort,
 		}
 		linkLabel.setListener(
 				(aSource, aLinkData) -> BrowserUtil.browse((String) aLinkData),
-				"https://github.com/krasa/StringManipulation/wiki/Hiarchical-sort");
+				"https://github.com/krasa/StringManipulation/wiki/Hierarchical-sort");
 	}
 
 	private void addPreviewListeners(Object object) {


### PR DESCRIPTION
The title of this GitHub Wiki page would need editing at the same time, and maybe add a temporary one redirecting people from the existing URL to the corrected one.