### PR TITLE
Add action which transforms to Spring Boot env variables

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -371,7 +371,11 @@
                         text="Invert case"
                         description="Invert Case -> iNVERT cASE">
                 </action>
-
+                <action id="StringManipulation.ToSpringEnvironmentVariable"
+                        class="osmedile.intellij.stringmanip.styles.ToSpringBootEnvironmentVariableAction"
+                        text="To Spring Boot Env variable"
+                        description="To Spring Boot Env variable">
+                </action>
                 <separator/>
                 <action id="StringManipulation.OpenSettingsAction"
                         class="osmedile.intellij.stringmanip.config.OpenSettingsAction"

--- a/src/osmedile/intellij/stringmanip/styles/Style.java
+++ b/src/osmedile/intellij/stringmanip/styles/Style.java
@@ -1,5 +1,7 @@
 package osmedile.intellij.stringmanip.styles;
 
+import osmedile.intellij.stringmanip.utils.StringUtil;
+
 import static osmedile.intellij.stringmanip.utils.StringUtil.*;
 
 public enum Style {
@@ -79,6 +81,12 @@ public enum Style {
 			}
 //			return WordUtils.capitalize(s, Constants.DELIMITERS);
 			return capitalizeFirstWord2(s);
+		}
+	},
+	SPRING_BOOT_ENVIRONMENT_VARIABLE("Spring Boot Env variable", "FOO_BAR") {
+		@Override
+		protected String transform(Style style, String s) {
+			return StringUtil.toSpringEnvVariable(s);
 		}
 	},
 	/**

--- a/src/osmedile/intellij/stringmanip/styles/ToSpringBootEnvironmentVariableAction.java
+++ b/src/osmedile/intellij/stringmanip/styles/ToSpringBootEnvironmentVariableAction.java
@@ -1,0 +1,10 @@
+package osmedile.intellij.stringmanip.styles;
+
+import java.util.Map;
+
+public class ToSpringBootEnvironmentVariableAction extends AbstractCaseConvertingAction {
+    @Override
+    public String transformByLine(Map<String, Object> actionContext, String s) {
+        return Style.SPRING_BOOT_ENVIRONMENT_VARIABLE.transform(s);
+    }
+}

--- a/src/osmedile/intellij/stringmanip/utils/StringUtil.java
+++ b/src/osmedile/intellij/stringmanip/utils/StringUtil.java
@@ -1,12 +1,14 @@
 package osmedile.intellij.stringmanip.utils;
 
 import org.apache.commons.lang3.CharUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import osmedile.intellij.stringmanip.config.PluginPersistentStateComponent;
 
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.lang.Character.isWhitespace;
 import static java.lang.Character.*;
@@ -243,7 +245,7 @@ public class StringUtil {
 //			boolean previousIsWhitespace = isWhitespace(previousChar);
 //			boolean lastOneIsNotUnderscore = buf.length() > 0 && buf.charAt(buf.length() - 1) != '_';
 //			boolean isNotUnderscore = c != '_';
-			//  ORIGINAL      if (lastOneIsNotUnderscore && (isUpperCase(c) || isLowerCaseAndPreviousIsWhitespace)) {  
+			//  ORIGINAL      if (lastOneIsNotUnderscore && (isUpperCase(c) || isLowerCaseAndPreviousIsWhitespace)) {
 
 			//camelCase handling - add extra _
 			if (isLetter(c) && isLetter(previousChar) && (isUpperCaseAndPreviousIsLowerCase || (putSeparatorBetweenUppercases() &&  isUpperCaseAndPreviousIsUpperCase))) {
@@ -760,6 +762,15 @@ public class StringUtil {
 		}
 		return result;
 	}
+
+    public static String toSpringEnvVariable(String s) {
+        return Arrays.stream(split(s, "."))
+                .map(StringUtils::trim)
+                .map(str -> StringUtils.replaceChars(str, "-", ""))
+                .map(str -> StringUtils.replaceChars(str, "_", ""))
+                .collect(Collectors.joining("_"))
+                .toUpperCase();
+    }
 
 
 	public static class Constants {

--- a/test/osmedile/intellij/stringmanip/utils/StringUtilTest.java
+++ b/test/osmedile/intellij/stringmanip/utils/StringUtilTest.java
@@ -101,4 +101,11 @@ public class StringUtilTest extends CaseSwitchingTest {
         assertEquals("_foo bar 1_1_", StringUtil.replaceSeparatorBetweenLetters("_foo_bar_1_1_", '_', ' '));
 
     }
+
+    @Test
+    public void toSpringRelaxedBinding() {
+        assertEquals("ACME_MYPROJECT_PERSON_FIRSTNAME", StringUtil.toSpringEnvVariable("acme.my-project.person.first-name"));
+        assertEquals("ACME_MYPROJECT_PERSON_FIRSTNAME", StringUtil.toSpringEnvVariable("acme.myProject.person.firstName"));
+        assertEquals("ACME_MYPROJECT_PERSON_FIRSTNAME", StringUtil.toSpringEnvVariable("acme.my_project.person.first_name"));
+    }
 }


### PR DESCRIPTION
I really like this plugin, it helps a lot. Sometimes in order to change Spring Boot properties to environment variables, I do manual actions. That's why I created this PR :) 

https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/boot-features-external-config.html#boot-features-external-config-relaxed-binding