### PR TITLE
Convert Between JSON and YAML action

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -555,6 +555,12 @@
                         text="Minify JavaScript"
                         description="Using github.com/wro4j/wro4j (requires JRE 1.9+)">
                 </action>
+                <separator/>
+                <action id="StringManipulation.ConvertJsonYamlAction"
+                        class="osmedile.intellij.stringmanip.transform.ConvertJsonYamlAction"
+                        text="Convert Between JSON and YAML"
+                        description="TODO">
+                </action>
             </group>
 
             <group text="Align..."

--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -492,8 +492,8 @@
                 </action>
             </group>
 
-            <group text="Filter/Remove/Trim/Minify..."
-                   description="Filter/Remove/Trim/Minify..."
+            <group text="Filter/Remove/Trim/Minify/Convert..."
+                   description="Filter/Remove/Trim/Minify/Convert..."
                    icon="/osmedile/intellij/stringmanip/icons/filter.svg"
                    popup="true">
                 <action id="osmedile.intellij.stringmanip.GrepAction"
@@ -559,7 +559,7 @@
                 <action id="StringManipulation.ConvertJsonYamlAction"
                         class="osmedile.intellij.stringmanip.transform.ConvertJsonYamlAction"
                         text="Convert Between JSON and YAML"
-                        description="TODO">
+                        description="Detect whether the selection is JSON or YAML (1.2) and convert to the other">
                 </action>
             </group>
 

--- a/src/osmedile/intellij/stringmanip/transform/ConvertJsonYamlAction.java
+++ b/src/osmedile/intellij/stringmanip/transform/ConvertJsonYamlAction.java
@@ -1,0 +1,70 @@
+package osmedile.intellij.stringmanip.transform;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.ui.Messages;
+import org.json.JSONObject;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
+import osmedile.intellij.stringmanip.AbstractStringManipAction;
+
+import javax.swing.*;
+import java.util.Map;
+
+public class ConvertJsonYamlAction extends AbstractStringManipAction<Object> {
+    private static final Logger LOG = Logger.getInstance(ConvertJsonYamlAction.class);
+
+    private final Dump yamlDump;
+    private final Gson gson;
+
+    public ConvertJsonYamlAction() {
+        DumpSettings yamlDumpSettings = DumpSettings.builder()
+            .setDefaultFlowStyle(FlowStyle.BLOCK)
+            .build();
+        yamlDump = new Dump(yamlDumpSettings);
+
+        gson = new GsonBuilder()
+            .setPrettyPrinting()
+            .serializeNulls()
+            .create();
+    }
+
+    @Override
+    protected String transformSelection(Editor editor, Map<String, Object> actionContext, DataContext dataContext, String selectedText, Object additionalParam) {
+        try {
+            String trimmedText = selectedText.trim();
+            return trimmedText.startsWith("{") || trimmedText.startsWith("[")
+                ? jsonToYaml(selectedText)
+                : yamlToJson(selectedText);
+        } catch (Throwable e) {
+            SwingUtilities.invokeLater(() -> Messages.showErrorDialog(editor.getProject(), String.valueOf(e), "Convert Between JSON and YAML"));
+            LOG.info(e);
+            throw new ProcessCanceledException(e);
+        }
+    }
+
+    protected String jsonToYaml(String text) {
+        JSONObject jsonObject = new JSONObject(text);
+        Map<String, Object> map = jsonObject.toMap();
+
+        return yamlDump.dumpToString(map).trim();
+    }
+
+    protected String yamlToJson(String selectedText) {
+        Yaml yaml = new Yaml();
+        Map<String, Object> map = yaml.load(selectedText);
+
+        return gson.toJson(map);
+    }
+
+    @Override
+    public String transformByLine(Map<String, Object> actionContext, String s) {
+        throw new RuntimeException();
+    }
+}

--- a/test/osmedile/intellij/stringmanip/transform/ConvertJsonYamlActionTest.java
+++ b/test/osmedile/intellij/stringmanip/transform/ConvertJsonYamlActionTest.java
@@ -1,0 +1,40 @@
+package osmedile.intellij.stringmanip.transform;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConvertJsonYamlActionTest {
+
+    @Test
+    public void jsonToYaml() {
+        String inputJson = readFile("input.json");
+        String outputYaml = readFile("output.yml");
+
+        String yaml = new ConvertJsonYamlAction().jsonToYaml(inputJson);
+        assertEquals(outputYaml, yaml);
+    }
+
+    @Test
+    public void yamlToJson() {
+        String inputYaml = readFile("input.yml");
+        String outputJson = readFile("output.json");
+
+        String json = new ConvertJsonYamlAction().yamlToJson(inputYaml);
+        assertEquals(outputJson, json);
+    }
+
+    private String readFile(String fileName) {
+        try {
+            return FileUtils.readFileToString(new File("test/osmedile/intellij/stringmanip/transform/data/" + fileName), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/test/osmedile/intellij/stringmanip/transform/data/input.json
+++ b/test/osmedile/intellij/stringmanip/transform/data/input.json
@@ -1,0 +1,18 @@
+{
+  "object": {
+    "key": "value",
+    "array": [
+      {
+        "null_value": null
+      },
+      {
+        "boolean": true
+      },
+      {
+        "integer": 1
+      }
+    ]
+  },
+  "paragraph": "Blank lines denote\n\nparagraph breaks\n",
+  "content": "Some\nmultiline\ncontent"
+}

--- a/test/osmedile/intellij/stringmanip/transform/data/input.yml
+++ b/test/osmedile/intellij/stringmanip/transform/data/input.yml
@@ -1,0 +1,22 @@
+---
+# a comment
+
+object:
+  key: value
+  array:
+    - null_value: null
+    - boolean: true
+    - integer: 1
+    - alias: &example example alias value
+    - alias: *example
+paragraph: |
+  Blank lines denote
+
+  paragraph breaks
+content: |-
+  Some
+  multiline
+  content
+alias: &foo
+  bar: baz
+alias_reuse: *foo

--- a/test/osmedile/intellij/stringmanip/transform/data/output.json
+++ b/test/osmedile/intellij/stringmanip/transform/data/output.json
@@ -1,0 +1,30 @@
+{
+  "object": {
+    "key": "value",
+    "array": [
+      {
+        "null_value": null
+      },
+      {
+        "boolean": true
+      },
+      {
+        "integer": 1
+      },
+      {
+        "alias": "example alias value"
+      },
+      {
+        "alias": "example alias value"
+      }
+    ]
+  },
+  "paragraph": "Blank lines denote\n\nparagraph breaks\n",
+  "content": "Some\nmultiline\ncontent",
+  "alias": {
+    "bar": "baz"
+  },
+  "alias_reuse": {
+    "bar": "baz"
+  }
+}

--- a/test/osmedile/intellij/stringmanip/transform/data/output.yml
+++ b/test/osmedile/intellij/stringmanip/transform/data/output.yml
@@ -1,0 +1,14 @@
+object:
+  key: value
+  array:
+  - null_value: null
+  - boolean: true
+  - integer: 1
+paragraph: |
+  Blank lines denote
+
+  paragraph breaks
+content: |-
+  Some
+  multiline
+  content


### PR DESCRIPTION
A new action "Convert Between JSON and YAML".

I put it under the "Filter/Remove/Trim/Minify" group and added "Convert" to it.

I've used org.json for reading the JSON (simplest) and Gson for writing it (better formatting). Gson and SnakeYAML (used for YAML read/write) are bundled with IntelliJ.

This was my first work with IntelliJ plugin so let me know if there is anything that should be done differently.

Closes #123 